### PR TITLE
fix: follow symlinks when scanning shared folder

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -697,7 +697,7 @@ fn index_path_with_progress(
     // Small commits make verified tracks visible without holding the database
     // while the rest of a large collection is scanned.
     for entry in WalkDir::new(folder)
-        .follow_links(false)
+        .follow_links(true)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|entry| entry.file_type().is_file() && supported_audio_path(entry.path()))


### PR DESCRIPTION
Addresses #3 
This allows me to have:
`/192.168.0.5/music       5,3T  5,3T  3,1G 100% /mnt/music`

and then `ln -s /mnt/music` in `~/.local/share/social.napstr.desktop/Downloads`.

What do you think? Or are symlinks intentionally disabled?